### PR TITLE
Fixing/upgrading FROM to sstarcher/sensu:0.26.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sstarcher/sensu 
+FROM sstarcher/sensu:0.26.5 
 
 # Enable Embedded Ruby
 RUN sed -i -r 's/EMBEDDED_RUBY=false/EMBEDDED_RUBY=true/' /etc/default/sensu

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,3 +12,4 @@ COPY resources/conf.d/* /etc/sensu/conf.d/
 COPY resources/check.d/ /etc/sensu/check.d/
 COPY resources/handlers/* /etc/sensu/handlers/
 COPY resources/plugins /etc/sensu/plugins/
+RUN chmod -R +x /etc/sensu/plugins


### PR DESCRIPTION
At the time of creation the FROM image wasn't being tagged, now it is, so we should use the fixed tag (sstarcher/sensu:0.26.5) instead of taking the latest all the time.

As this also upgrades Sensu, I've included a new version of the check_http.rb from https://github.com/sensu-plugins/sensu-plugins-http so that the checks don't say our current method is deprecated.

I also fixed the Dockerfile to apply the execute bit to plugins, as due to a mistake whilst developing this I realised it was just using the execute bit set in the repo instead which isn't immediately obvious.