### PR TITLE
Adding plugins for host checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,17 @@ RUN sed -i -r 's/EMBEDDED_RUBY=false/EMBEDDED_RUBY=true/' /etc/default/sensu
 RUN /opt/sensu/embedded/bin/gem install mail --version 2.5.4
 RUN /opt/sensu/embedded/bin/gem install aws-ses
 
+# Install plugins
+RUN /opt/sensu/embedded/bin/gem install sensu-plugins-disk-checks --version 2.4.0
+RUN /opt/sensu/embedded/bin/gem install sensu-plugins-process-checks --version 2.4.0
+RUN /opt/sensu/embedded/bin/gem install sensu-plugins-memory-checks --version 3.0.2
+RUN /opt/sensu/embedded/bin/gem install sensu-plugins-network-checks --version 2.0.1
+RUN /opt/sensu/embedded/bin/gem install sensu-plugins-cpu-checks --version 1.1.2
+RUN /opt/sensu/embedded/bin/gem install sensu-plugins-filesystem-checks --version 1.0.0
+RUN /opt/sensu/embedded/bin/gem install sensu-plugins-load-checks --version 2.0.0
+RUN /opt/sensu/embedded/bin/gem install sensu-plugins-uptime-checks --version 1.1.0
+RUN /opt/sensu/embedded/bin/gem install sensu-plugins-io-checks --version 1.0.1
+
 # Bake config & checks in
 COPY resources/conf.d/* /etc/sensu/conf.d/
 COPY resources/check.d/ /etc/sensu/check.d/


### PR DESCRIPTION
Adding a bunch of community Sensu plugins for host-style checks.

The existing plugins that have been added can remain, as updating the checks will require the Client container to be started differently and that will come later over in adop-docker-compose.